### PR TITLE
Fixes the compile-time failure with tiny go

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,17 @@ package main
 import (
 	"time"
 
-	// this helps with stutering, for example wjsu.Console.Log, 100% optional.
-	. "github.com/OneOfOne/wjsu"
+	"github.com/OneOfOne/wjsu"
 )
 
 func main() {
-	Console.Log("hello console", []int{1, -1}, map[string]float64{"a": 1, "z": -1})
-	Document.QuerySelector("div#loader").SetInnerHTML("hello world")
+    if err := wjsu.Initialize(); err != nil {
+        panic(err)
+    }
+	wjsu.Console.Log("hello console", []int{1, -1}, map[string]float64{"a": 1, "z": -1})
+	wjsu.Document.QuerySelector("div#loader").SetInnerHTML("hello world")
 
-	app := Document.QuerySelector("app")
+	app := wjsu.Document.QuerySelector("app")
 	for t := range time.Tick(time.Second) {
 		app.SetInnerHTML("time (UTC): " + t.UTC().String())
 	}

--- a/dom.go
+++ b/dom.go
@@ -10,8 +10,13 @@ var (
 	document = js.Global().Get("document")
 	head     = document.Get("head")
 
-	Document = HTMLDocument{HTMLElement{document}}
+	Document HTMLDocument
 )
+
+func Initialize() error {
+	Document = HTMLDocument{HTMLElement{document}}
+	return nil
+}
 
 func RawDocument() js.Value { return document }
 


### PR DESCRIPTION
Added an Initialization function to the whole library to avoid trivial compile-time errors. This can also be used in the future for more complicated Initialization logic that shouldn't be done in the global scope and/or is error prone.

For more infomation, see https://github.com/tinygo-org/tinygo/issues/727#issuecomment-554582530